### PR TITLE
メッセージ送信機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,4 @@ gem "font-awesome-rails"
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'haml-rails'
 gem "font-awesome-rails"
 gem 'devise'
+gem 'carrierwave'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -112,6 +113,11 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (0.6.3)
@@ -208,6 +214,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,10 @@ GEM
     bindex (0.7.0)
     builder (3.2.3)
     byebug (11.0.1)
+    carrierwave (1.3.1)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -96,6 +100,10 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
+    mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -190,6 +198,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   font-awesome-rails
@@ -197,6 +206,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Things you may want to cover:
 |------|----|-------|
 |user|references|null: false, foreign_key: true|
 |group|references|null: false, foreign_key: true|
-|body|text||
+|content|text||
 |image|string||
 
 ### Association

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -105,7 +105,7 @@
     padding-left: 10px;
   }
 }
-.message__text{
+.message__lower__content{
   @include text($text-color2, 14px);
   font-weight: normal;
 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,4 +1,7 @@
 class MessagesController < ApplicationController
   def index
   end
+
+  def create
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,7 +1,29 @@
 class MessagesController < ApplicationController
+  before_action :set_group
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
   end
 
   def create
+    @message = @group.messages.new(message_params)
+
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users
   has_many :users, through: :group_users
+  has_many :messages
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,6 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,49 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  process resize_to_fit: [800, 800]
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -7,7 +7,7 @@
           %li= message
   .chat-group-form__field
     .chat-group-form__field--left
-      = f.label :name, class: 'chat-group-form__label'
+      = f.label :name,"グループ名" , class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,0 +1,11 @@
+.message
+  .message__upper
+    .message__upper__name
+      = message.user.name
+    .message__upper__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  .message__lower
+    - if message.content.present?
+      %p.message__lower__content
+        = message.content
+    = image_tag message.image.url, class: 'message__lower__image' if message.image.present?

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -15,4 +15,4 @@
           .group__name
             = group.name
           .group__message
-            メッセージはまだありません。
+            = group.show_last_message

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,25 +4,20 @@
     .header
       .header__left
         .header__left__group
-          Group
+          =@group.name
         .header__left__members
-          Member
+          Member : 
+          - @group.group_users.each do |group_user|
+            = group_user.user.name
       =link_to "", class: "header__btn" do
         EDIT
     .messages
-      .message
-        .message__upper
-          .message__upper__name
-            Name
-          .message__upper__date
-            Date
-        .message__text
-          Text
+      = render @messages
     .form
-      %form.box
+      = form_for [@group, @message], html: { class: 'box', id: 'box' } do |f|
         .box__input
-          %input.box__input__text{type:"text", name:"message", placeholder:'type a message'}
-          %label.box__input__upload-label{for: "upload-icon"}
-            =fa_icon "image"
-            %input.box__input__upload-label__icon{type: "file", id: "upload-icon"}
-        %input.box__btn{type:"submit", value:"Send"}
+          = f.text_field :content, class: 'box__input__text', placeholder: 'type a message'
+          = f.label :image, class: 'box__input__upload-label' do
+            = fa_icon 'picture-o'
+            = f.file_field :image, class: 'box__input__upload-label__icon'
+        = f.submit 'Send', class: 'box__btn'

--- a/db/migrate/20190719044627_create_messages.rb
+++ b/db/migrate/20190719044627_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[5.0]
+  def change
+    create_table :messages do |t|
+      t.text :content
+      t.string :image
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190716134157) do
+ActiveRecord::Schema.define(version: 20190719044627) do
 
   create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "group_id"
@@ -26,6 +26,17 @@ ActiveRecord::Schema.define(version: 20190716134157) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
+
+  create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.text     "content",    limit: 65535
+    t.string   "image"
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["group_id"], name: "index_messages_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_messages_on_user_id", using: :btree
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -44,4 +55,6 @@ ActiveRecord::Schema.define(version: 20190716134157) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
+  add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
#What 
・Messageモデルとコントローラの作成
・User、Group、Messageモデル間のアソシエーション定義
・Messageのcontentカラムにバリデーションを定義
・Messageのルーティングを定義(index, create)
・「CarrierWave 」と「MiniMagick」の導入
・メッセージを保存できるようViewファイルをform_forを使って書き換え
・投稿されたメッセージをビューに表示
・サイドバーのグループ部分に最新のメッセージを表示
＃Why　
・メッセージ投稿時に文章と画像を送信できる機能を実装するため