### PR TITLE
メッセージの自動更新機能実装

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -23,47 +23,51 @@ $(function() {
     user_list.append(html);
   }
 
-  $("#user-search-field.chat-group-form__input").on("keyup", function() {
-    var input = $("#user-search-field.chat-group-form__input").val();
-    if (input != ""){
-      $.ajax({
-        type: 'GET',
-        url: '/users',
-        data: { keyword: input },
-        dataType: 'json'
-      })
-      .done(function(users) {
-        $("#user-search-result").empty();
-        if (users.length !== 0) {
-          users.forEach(function(user){
-            searchUser(user);
-          });
-          return users
-        }
-        else {
-          appendErrMsgToHTML("一致するユーザーはいません");
-        }
+  $(function () {
+    $("#user-search-field.chat-group-form__input").on("keyup", function() {
+      var input = $("#user-search-field.chat-group-form__input").val();
+      if (input != ""){
+        $.ajax({
+          type: 'GET',
+          url: '/users',
+          data: { keyword: input },
+          dataType: 'json'
+        })
+        .done(function(users) {
+          $("#user-search-result").empty();
+          if (users.length !== 0) {
+            users.forEach(function(user){
+              searchUser(user);
+            });
+            return users
+          }
+          else {
+            appendErrMsgToHTML("一致するユーザーはいません");
+          }
 
-      })
-      .fail(function() {
-        alert('error');
-      });
-    }
+        })
+        .fail(function() {
+          alert('error');
+        });
+      }
+    });
   });
-  var add_user_ids = [];
-  search_list.on("click", ".chat-group-user__btn", function() {
-    var user_id = $(this).data('userId');
-    var user_name = $(this).data('userName');
-    add_user_ids.push(user_id);
-　  if($.inArray(user_id,gon.group_id_list) === -1) {
+
+  $(function () {
+    search_list.on("click", ".chat-group-user__btn", function() {
+      var user_id = $(this).data('userId');
+      var user_name = $(this).data('userName');
       $(this.previousElementSibling).remove();
       $(this).remove();
       appendUserToGroup(user_id, user_name);
-    }
+    });
   });
 
-  user_list.on("click", ".user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn", function() {
-    $(this.previousElementSibling).remove();
-    $(this).remove();
+  $(function (users) {
+    user_list.on("click", ".user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn", function() {
+      var test = $(this).parent();
+      $(this).parent().remove();
+
+    });
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     var content = message.content ? `${ message.content }` : "";
     var image = message.image ? `<img class="message__lower__image" src= ${ message.image }>` : "";
-    var html = `<div class="message" data-message_id="${ message.id }">
+    var html = `<div class="message" data-message-id="${ message.id }">
                   <div class="message__upper">
                     <p class="message__upper__name">
                       ${message.user_name}
@@ -52,8 +52,10 @@ $(function(){
       $('.box__btn').prop('disabled', false);
     })
   })
+  
   var reloadMessages = function() {
-    last_message_id = $('.message').last().data('messageId');
+    var last_message_id = $('.message:last').data('messageId');
+    console.log(last_message_id);
     $.ajax({
       url: 'api/messages',
       type: 'get',
@@ -61,7 +63,8 @@ $(function(){
       data: {id: last_message_id}
     })
     .done(function(messages) {
-      console.log('success');
+      console.log(messages);
+      
       var insertHTML = '';
       if (messages.length !== 0) {
         messages.forEach(function(message){
@@ -76,8 +79,9 @@ $(function(){
       console.log('error');
       alert('自動更新に失敗しました');
     });
+    
   };
   if (location.href.match(/\/groups\/\d+\/messages/)){
-    setInterval(reloadMessages, 5000);
+    setInterval(reloadMessages, 3000);
   }
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     var content = message.content ? `${ message.content }` : "";
     var image = message.image ? `<img class="message__lower__image" src= ${ message.image }>` : "";
-    var html = `<div class="message">
+    var html = `<div class="message" data-message_id="${ message.id }">
                   <div class="message__upper">
                     <p class="message__upper__name">
                       ${message.user_name}
@@ -22,10 +22,8 @@ $(function(){
   }
 
   function scrollBottom(){
-    var target = $('.message').last();
-    var position = target.offset().top + $('.messages').scrollTop();
     $('.messages').animate({
-      scrollTop: position
+      scrollTop: $('.messages')[0].scrollHeight
     }, 300, 'swing');
   }
 
@@ -54,4 +52,32 @@ $(function(){
       $('.box__btn').prop('disabled', false);
     })
   })
+  var reloadMessages = function() {
+    last_message_id = $('.message').last().data('messageId');
+    $.ajax({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      console.log('success');
+      var insertHTML = '';
+      if (messages.length !== 0) {
+        messages.forEach(function(message){
+          insertHTML += buildHTML(message);
+        });
+      }
+      var messageHTML = $('.messages');
+      messageHTML.append(insertHTML);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
+    })
+    .fail(function() {
+      console.log('error');
+      alert('自動更新に失敗しました');
+    });
+  };
+  if (location.href.match(/\/groups\/\d+\/messages/)){
+    setInterval(reloadMessages, 5000);
+  }
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -55,16 +55,13 @@ $(function(){
   
   var reloadMessages = function() {
     var last_message_id = $('.message:last').data('messageId');
-    console.log(last_message_id);
     $.ajax({
       url: 'api/messages',
       type: 'get',
       dataType: 'json',
       data: {id: last_message_id}
     })
-    .done(function(messages) {
-      console.log(messages);
-      
+    .done(function(messages) {   
       var insertHTML = '';
       if (messages.length !== 0) {
         messages.forEach(function(message){
@@ -76,7 +73,6 @@ $(function(){
       $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');
     })
     .fail(function() {
-      console.log('error');
       alert('自動更新に失敗しました');
     });
     

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,8 +1,9 @@
 class Api::MessagesController < ApplicationController
+  protect_from_forgery except: :index
   before_action :set_group
   def index
     @messages = @group.messages.includes(:user).where('id > ?', params[:id])
-    respond_to do |format| 
+    respond_to do |format|
       format.html
       format.json
     end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,14 @@
+class Api::MessagesController < ApplicationController
+  before_action :set_group
+  def index
+    @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+    respond_to do |format| 
+      format.html
+      format.json
+    end
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,6 +7,8 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
     @group.users << current_user
+    @users = @group.users
+    
   end
 
   def create
@@ -19,17 +21,12 @@ class GroupsController < ApplicationController
   end
 
   def edit
-    gon.group = @group
-    gon.users = @group.users
-    gon.group_id_list = []
-    gon.users.each do |user|
-      id = user.id
-      gon.group_id_list << id
-    end
+    @users = @group.users.where.not(id: current_user.id)
   end
 
   def update
     if @group.update(group_params)
+      # binding.pry
       redirect_to group_messages_path(@group), notice: 'グループを編集しました'
     else
       render :edit

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -3,6 +3,11 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    # @messages = @group.messages.includes(:user).where('id > ?', params[:id])
+    # respond_to do |format|
+    #   format.html
+    #   format.json
+    # end
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
   end
 
   def index
-    @users = User.where('name LIKE(?)', "#{params[:keyword]}%").where.not(id:current_user.id)
+    @users = User.where('name LIKE(?)', "#{params[:keyword]}%")
     respond_to do |format|
       format.html
       format.json

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content    message.content
+  json.image      message.image.url
+  json.date       message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name  message.user.name
+  json.id         message.id
+end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,6 +10,7 @@
       = f.label :name,"グループ名" , class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバーを追加", class: "chat-group-form__label", for: "chat_group_チャットメンバーを追加"
@@ -17,6 +18,7 @@
       .chat-group-form__search.clearfix
         = f.text_field :name, value:"", name: "keyword", class: "chat-group-form__input", placeholder: "追加したいユーザー名を入れてください", id: 'user-search-field'
       #user-search-result
+  
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label "チャットメンバー", class: "chat-group-form__label", for: "chat_group_チャットメンバー"

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,14 +24,16 @@
       = f.label "チャットメンバー", class: "chat-group-form__label", for: "chat_group_チャットメンバー"
     .chat-group-form__field--right
       #chat-group-users
-        .chat-group-user.clearfix#current_user.id
-          = f.hidden_field :name, name:'chat_group[user_ids][]', value:current_user.id
+        .chat-group-user.clearfix{ data: { user_id: current_user.id, user_name: current_user.name } }
+          = f.hidden_field :name, name:'group[user_ids][]', value:current_user.id
           %p.chat-group-user__name= current_user.name
-        - group.group_users.each do |group_user|
-          .chat-group-user.clearfix#group_user_user.id
-            = f.hidden_field :name, id:group_user.user.name, value: group_user.user.id, name: "group[user_ids][]"
-            %p.chat-group-user__name= group_user.user.name
-            .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+        = render partial: 'user', collection: @users
+        -# - users.each do |user|
+        -#   .chat-group-user.clearfix{ data: { user_id: user.id, user_name: user.name } }
+        -#     = f.hidden_field :name, id:user.name, value: user.id, name: "group[user_ids][]"
+        -#     %p.chat-group-user__name
+        -#       = user.name
+        -#     .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_user.html.haml
+++ b/app/views/groups/_user.html.haml
@@ -1,0 +1,5 @@
+.chat-group-user.clearfix{ data: { user_id: user.id, user_name: user.name } }
+  %input{type: "hidden", value: user.id, name: 'group[user_ids][]'}
+  %p.chat-group-user__name
+    = user.name
+  .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = render 'form', { group: @group }
+  = render 'form', { group: @group, users: @users }

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: { message_id: message.id } }
   .message__upper
     .message__upper__name
       = message.user.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# WHAT
### 数秒おきに自動で、ブラウザに表示されているメッセージのうち最新のメッセージのidをサーバにリクエストする。サーバ側ではそれよりも後に投稿されたメッセージのみを取得してレスポンスし、最後にそれをクライアント側で加工、メッセージ一覧に追加する。

#### １、メッセージのHTMLにメッセージにカスタムデータ属性’data-message_id’を付与
#### ２、api/messages_controller.rbにindexアクションを定義
　＊送られてきたメッセージのidを取得してそれよりも後に投稿されたメッセージのみDBから取得する
#### ３、controllers/api/messages_controller.rbに追加したindexアクションを動かすルーティングの設定
　＊namespace :api(ディレクトリ名) do ~ endと記述し、apiディレクトリ内のコントローラアクションを指定
　＊defaultsオプションを利用して、このルーティングが来たらjson形式でレスポンスするよう指定
#### ４、index.json.jbuilderの作成
#### ５、message.jsに、作成したアクションをreloadMessagesという関数にして定義
#### ６、setInterval()関数を使用し、定義した関数reloadMessagesを5秒置きに呼び出すよう設定
#### ７、animateメソッドを使用し、非同期通信で新しく追加されたメッセージの分だけ上にスクロールさせ、追加されたメッセージが画面内にに表示されるようにする
#### ８、グループのメッセージ一覧でのみ自動更新が行われるようにする
　＊location.hrefで現在表示されているページのURLを取得し、グループのメッセージ一覧ページのパスと比較して一致した場合のみsetInterval()関数が呼び出されるよう定義

# WHY
### ChatSpaceでメッセージ画面が自動で更新されることで、自分以外のユーザーが送信したメッセージも更新時に表示されるようにするため

https://gyazo.com/023f53817c1168cff6a09a8886adbfd1